### PR TITLE
feat(UseCase): module _use_case.py, class DefaultUseCase in _widget.py

### DIFF
--- a/src/napari_potential_field_navigation/_use_case.py
+++ b/src/napari_potential_field_navigation/_use_case.py
@@ -1,0 +1,123 @@
+from functools import wraps
+
+
+class UseCase:
+    """
+    The UseCase class allows enabling or disabling elements of a chain of
+    dependencies
+    """
+    def __init__(self):
+        self._steps = []
+        self._requirements = {}
+        self._state = {}
+
+    def involve(self, steps):
+        self._steps.extend(steps)
+        for step in steps:
+            step._use_case = self
+
+    def start(self):
+        self._init_state()
+        for step in self._steps:
+            for conditional_step in self._requirements.keys():
+                if isinstance(step, conditional_step):
+                    self.disable(step)
+                    break
+
+    def _init_state(self):
+        for requirements in self._requirements.values():
+            if not requirements:
+                raise Exception(
+                    "Empty list of requirements; do not reference such steps"
+                )
+            for requirement in requirements:
+                checkpoint = requirement.__qualname__
+                self._state[checkpoint] = False
+
+    def is_involved(self, step):
+        try:
+            return step._use_case is self
+        except AttributeError:
+            return False
+
+    def _disable(self, step):
+        return False
+
+    def _enable(self, step):
+        return False
+
+    def disable(self, step):
+        ret = False
+        if self.is_involved(step):
+            try:
+                ret = self._disable(step)
+            except Exception as exception:
+                logging.error(
+                    f"""Disabling step of type {type(step)} failed with exception:
+                    {exception}
+                    """
+                )
+            # TODO: should we also clear the state?
+        else:
+            logging.error(
+                "Trying to disable a step the use case does not involve"
+            )
+        return ret
+
+    def enable(self, step):
+        ret = False
+        if self.is_involved(step):
+            try:
+                ret = self._enable(step)
+            except Exception as exception:
+                logging.error(
+                    f"""Enabling step of type {type(step)} failed with exception:
+                    {exception}
+                    """
+                )
+        else:
+            logging.error(
+                "Trying to enable a step the use case does not involve"
+            )
+        return ret
+
+    def _ready(self, obj, met, ret):
+        return True
+
+    def notify_update(self, obj, met, ret):
+        cls = type(obj)
+        for checkpoint in self._state.keys():
+            if checkpoint in (cls.__qualname__, met.__qualname__):
+                ready = self._ready(obj, met, ret)
+                assert ready is True
+                if ready is None:
+                    ready = True
+                self._state[checkpoint] = ready
+                break
+        self._refresh()
+
+    def _check_state(self, step):
+        for conditional_step in self._requirements.keys():
+            if type(step) is conditional_step:
+                for requirement in self._requirements[conditional_step]:
+                    checkpoint = requirement.__qualname__
+                    if not self._state[checkpoint]:
+                        return False
+        return True
+
+    def _refresh(self):
+        for step in self._steps:
+            if self._check_state(step):
+                self.enable(step)
+            else:
+                self.disable(step)
+
+
+def use_case_check_point(f):
+    @wraps(f)
+    def method_with_check_point(self, *args, **kwargs):
+        ret = f(self, *args, **kwargs)
+        self._use_case.notify_update(self, f, ret)
+        return ret
+    return method_with_check_point
+

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -36,6 +36,11 @@ from napari_potential_field_navigation.simulations import (
 )
 import csv
 
+from napari_potential_field_navigation._use_case import (
+    UseCase,
+    use_case_check_point,
+)
+
 if TYPE_CHECKING:
     import napari
 
@@ -76,11 +81,12 @@ class IoContainer(widgets.Container):
             ]
         )
 
-    def _read_image(self):
+    @use_case_check_point
+    def _read_image(self, image_path):
         if "Image" in self._viewer.layers:
             self._viewer.layers.remove("Image")
         self._viewer.open(
-            self._image_reader.value,
+            image_path,
             plugin="napari-itk-io",
             layer_type="image",
             name="Image",
@@ -91,11 +97,12 @@ class IoContainer(widgets.Container):
             idx = self._viewer.layers.index("Label")
             self._viewer.layers.move(idx, -1)
 
-    def _read_label(self):
+    @use_case_check_point
+    def _read_label(self, label_path):
         if "Label" in self._viewer.layers:
             self._viewer.layers.remove("Label")
         labels = self._viewer.open(
-            self._label_reader.value,
+            label_path,
             plugin="napari-itk-io",
             layer_type="image",
             name="Label_temp",
@@ -168,6 +175,7 @@ class PointContainer(widgets.Container):
             ]
         )
 
+    @use_case_check_point
     def _select_source(self):
         if "Goal" in self._viewer.layers:
             self._viewer.layers.remove("Goal")
@@ -184,6 +192,7 @@ class PointContainer(widgets.Container):
         self._viewer.layers.selection = [self._goal_layer]
         self._goal_layer.mode = "add"
 
+    @use_case_check_point
     def _select_positions(self):
         if "Initial positions" not in self._viewer.layers:
             self._position_layer = self._viewer.add_points(
@@ -370,6 +379,7 @@ class InitFieldContainer(widgets.Container, ABC):
 
 
 class WavefrontContainer(InitFieldContainer):
+    @use_case_check_point
     def compute(self) -> bool:
         if "Label" not in self._viewer.layers:
             notifications.show_error(
@@ -433,6 +443,7 @@ class WavefrontContainer(InitFieldContainer):
 
 
 class AStarContainer(InitFieldContainer):
+    @use_case_check_point
     def compute(self) -> bool:
         if "Label" not in self._viewer.layers:
             notifications.show_error(
@@ -562,6 +573,7 @@ class AStarContainer(InitFieldContainer):
 
 
 class LaplaceContainer(InitFieldContainer):
+    @use_case_check_point
     def compute(self):
         if "Label" not in self._viewer.layers:
             notifications.show_error(
@@ -702,6 +714,7 @@ class ApfContainer(InitFieldContainer):
         self._distance_field = None
         self._bounds = None
 
+    @use_case_check_point
     def compute(self) -> bool:
         if "Label" not in self._viewer.layers:
             notifications.show_error(
@@ -1496,6 +1509,8 @@ class DiffApfWidget(widgets.Container):
         # self._method_container = ApfContainer(self._viewer)
         self._method_container = LaplaceContainer(self._viewer)
 
+        self._use_case = DefaultUseCase(type(self._method_container))
+
         self._simulation_container = SimulationContainer(
             self._viewer, self._method_container
         )
@@ -1509,6 +1524,8 @@ class DiffApfWidget(widgets.Container):
         )
         self.max_width = 700
 
+        self._use_case.start()
+
     # def _update_method(self, index: int):
     # Change the visible widget in the stacked widget to the selected method
     # self._stackedWidget.setCurrentIndex(index)
@@ -1521,3 +1538,45 @@ class DiffApfWidget(widgets.Container):
     #     self._method_container = AStarContainer(self._viewer)
     # else:
     #     raise ValueError("Unknown method selection")
+
+    def extend(self, components):
+        if hasattr(self, "_use_case"):
+            self._use_case.involve(components)
+        super().extend(components)
+
+
+class DefaultUseCase(UseCase):
+    def __init__(self, InitFieldContainer: type):
+        super().__init__()
+        # Reminder: self._requirements[downstream] = upstream
+        self._requirements[PointContainer] = [
+            IoContainer._read_image, IoContainer._read_label
+        ]
+        self._requirements[InitFieldContainer] = [PointContainer._select_source]
+        self._requirements[SimulationContainer] = [
+            PointContainer._select_positions, InitFieldContainer.compute
+        ]
+        if InitFieldContainer is AStarContainer:
+            self._requirements[InitFieldContainer].append(
+                PointContainer._select_positions
+            )
+
+    def _disable(self, container: widgets.Container):
+        container.enabled = False
+
+    def _enable(self, container: widgets.Container):
+        container.enabled = True
+
+    def _ready(self, container, method, returned_value):
+        if method is IoContainer._read_image:
+            return "Image" in container._viewer.layers
+        elif method is IoContainer._read_label:
+            return "Label" in container._viewer.layers
+        elif method is PointContainer._select_source:
+            return "Goal" in container._viewer.layers
+        elif method is PointContainer._select_positions:
+            return "Initial positions" in container._viewer.layers
+        elif isinstance(returned_value, bool):
+            return returned_value
+        else:
+            return True


### PR DESCRIPTION
This PR implements a prototype for use cases, so that widget containers can be unlocked following some dependency rules.

# Motivation

Almost all UI fields are accessible/editable from loading the app, which can be overwhelming for newcomers. It is hard to understand the intended flow of actions, from data loading to optimizing the field, and easy to trigger an error message about unsatisfied constraints.

We need to lock/disable some UI elements as long as the prerequisites for the step they correspond to are not met.

The identified flow of actions is as follows:
1. data loading
2. image cropping
3. a. goal definition
    b. starting point definition
4. field initialization
5. a. trajectory simulation
    b. field optimization

Step 2. requires step 1. but is currently optional and may become part of step 1 (see PR [!4](https://github.com/rcremese/napari-potential-field-navigation/pull/4)). Step 3 requires step 1. Step 4 requires step 3.a. Steps 5 requires steps 3 and 4.

A special case that can be triggered only with code changes (subtituting `LaplaceContainer` for `AStarContainer` in module `_widget.py`) would make step 4 require the entire step 3 (3.b. in addition to 3.a.)

# Changes

A new `_use_case.py` module defines a `UseCase` class and a `@use_case_check_point` decorator.

These new functionalites are imported into `_widget.py`, where a `DefaultUseCase` class is defined to specify a workflow. The `DefaultUseCase` class is instantiated in `DiffApfWidget.__init__`, and the latter is closed with a call to `UseCase.start`. This implicitly adds a `_use_case` attribute to the objects of type `widgets.Container` defined in the `__init__` method.

The `@use_case_check_point` decorator is applied the following methods:
* `IoContainer._read_image`
* `IoContainer._read_label`
* `PointContainer._select_source`
* `PointContainer._select_positions`
* `WavefrontContainer.compute`
* `AStarContainer.compute`
* `LaplaceContainer.compute`
* `ApfContainer.compute`

Additionally, the `IoContainer._read_image` and `IoContainer._read_label` now takes a filepath as input argument, as passed by the `widgets.FileEdit.changed.connect` callback registration functions. Surprisingly, the corresponding signals did not trigger an error on attempting to pass the extra argument. The behavior of `widgets.FileEdit.changed.connect` became clear with the decorated variants of the `_read_*` methods.

# Tests

Two sequences of actions only for now:
* (1) pick image file, (2) pick label file, (3) crop, (4) pick goal, (5) run Laplace initialization, (6) pick one starting point;
* same as above, switching steps (5) and (6).

The expected behavior includes:
* Steps (4) and (6) become available after steps (1) and (2) are complete,
* Step (5) becomes available after step (4) is complete,
* The entire simulation and optimization containers become available after steps (5) and (6) are complete.

# Current limitations

The downstream steps of goal/point positioning are unlocked on starting the positioning process, before the points are actually defined.