### PR TITLE
fix(IoContainer): handle file opening events from viewer or File menu

### DIFF
--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -153,6 +153,8 @@ class IoContainer(widgets.Container):
         if layer.name not in ("Image", "Label_temp", "Label"):
             # the layer was added using the viewer or File menu, for example by
             # copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
+            if "Image" in self._viewer.layers:
+                self._viewer.layers.remove("Image")
             layer.name = "Image"
 
             if "Label" in self._viewer.layers:

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -149,16 +149,21 @@ class IoContainer(widgets.Container):
     def _handle_layers_from_other_readers(self, event):
         # the newly inserted layer is the last one in the layer list
         layer = event.source[-1]
-        if isinstance(layer, napari.layers.image.image.Image) and \
-                layer.name not in ("Image", "Label_temp"):
-            # the layer was added using the viewer or File menu, for example by
-            # copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
-            if "Image" in self._viewer.layers:
-                self._viewer.layers.remove("Image")
-            layer.name = "Image"
+        if isinstance(layer, napari.layers.image.image.Image):
+            if layer.name not in ("Image", "Label_temp"):
+                # the layer has been added using the viewer or File menu, i.e.
+                # by copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
+                if "Image" in self._viewer.layers:
+                    self._viewer.layers.remove("Image")
+                layer.name = "Image"
 
-            if "Label" in self._viewer.layers:
-                self._crop_image()
+                if "Label" in self._viewer.layers:
+                    self._crop_image()
+
+            # any new Image layer is moved first (below all the other layers)
+            nlayers = len(self._viewer.layers)
+            if nlayers > 1:
+                self._viewer.layers.move(nlayers-1, 0)
 
 class PointContainer(widgets.Container):
     def __init__(self, viewer: "napari.viewer.Viewer"):

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -55,6 +55,9 @@ class IoContainer(widgets.Container):
         # Image
         self._image_reader = widgets.FileEdit(label="Image path")
         self._image_reader.changed.connect(self._read_image)
+        self._viewer.layers.events.inserted.connect(
+            self._handle_layers_from_other_readers
+        )
 
         # Label
         self._label_reader = widgets.FileEdit(label="Label path")
@@ -144,6 +147,16 @@ class IoContainer(widgets.Container):
             ## TODO : uncomment to get the image at the right resolution
             self._viewer.layers["Image"].translate = new_origin
 
+    def _handle_layers_from_other_readers(self, event):
+        # the newly inserted layer is the last one in the layer list
+        layer = event.source[-1]
+        if layer.name not in ("Image", "Label_temp", "Label"):
+            # the layer was added using the viewer or File menu, for example by
+            # copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
+            layer.name = "Image"
+
+            if "Label" in self._viewer.layers:
+                self._crop_image()
 
 class PointContainer(widgets.Container):
     def __init__(self, viewer: "napari.viewer.Viewer"):

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -149,16 +149,17 @@ class IoContainer(widgets.Container):
     def _handle_layers_from_other_readers(self, event):
         # the newly inserted layer is the last one in the layer list
         layer = event.source[-1]
-        if isinstance(layer, napari.layers.image.image.Image):
-            if layer.name not in ("Image", "Label_temp"):
-                # the layer has been added using the viewer or File menu, i.e.
-                # by copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
-                if "Image" in self._viewer.layers:
-                    self._viewer.layers.remove("Image")
-                layer.name = "Image"
+        if isinstance(layer, napari.layers.image.image.Image) and \
+                layer.name not in ("Image", "Label_temp") and \
+                not layer.name.endswith(" field"):
+            # the layer has been added using the viewer or File menu, i.e.
+            # by copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
+            if "Image" in self._viewer.layers:
+                self._viewer.layers.remove("Image")
+            layer.name = "Image"
 
-                if "Label" in self._viewer.layers:
-                    self._crop_image()
+            if "Label" in self._viewer.layers:
+                self._crop_image()
 
             # any new Image layer is moved first (below all the other layers)
             nlayers = len(self._viewer.layers)

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -36,8 +36,7 @@ from napari_potential_field_navigation.simulations import (
 )
 import csv
 
-if TYPE_CHECKING:
-    import napari
+import napari
 
 
 class MethodSelection(Enum):
@@ -150,7 +149,8 @@ class IoContainer(widgets.Container):
     def _handle_layers_from_other_readers(self, event):
         # the newly inserted layer is the last one in the layer list
         layer = event.source[-1]
-        if layer.name not in ("Image", "Label_temp", "Label"):
+        if isinstance(layer, napari.layers.image.image.Image) and \
+                layer.name not in ("Image", "Label_temp"):
             # the layer was added using the viewer or File menu, for example by
             # copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
             if "Image" in self._viewer.layers:


### PR DESCRIPTION
This PR adds support for file opening events from the viewer (Ctrl+O, drag-n-drop, copy-paste) and the File menu (“Open File(s)...”).

Anticipating PR [!4](https://github.com/rcremese/napari-potential-field-navigation/pull/4), the new method introduced to implement the above features triggers image cropping on loading an image while labels are already available.

# Motivation

Napari features various mechanims for loading image files, loaded per default as Image layers. The app adds its own widget to load image files and only supports files loaded using this widget. In addition, the app does not disable the native mechanisms.

When loaded using the native mechanisms, the Image layer is named after the loaded file, while the app expects the Image layer to be called “Image”. As a consequence, these layers are just ignored.

We need to handle these cases and, for example, to rename a newly added layer “Image” so that it is accounted for at later stages in the app.

# Changes

A `_handle_layers_from_other_readers` method is added to class `IoContainer`. It is a callback bound to the `Viewer.layers.events.inserted` event.

The `import napari` statement is evaluated unconditionally to bring the `napari.layers.image.image.Image` datatype into the module's namespace.

# Tests

(1) Loading an image with “File” > “Open file(s)...”, drag-and-dropping a file from the graphical file browser, copy-pasting a file from a graphical file browser (not the file's content) and pressing Ctrl+O.

(2) Loading a label file first, with the dedicated widget, and then loading an image in any of the above native ways.

(3) Proceeding to the next processing steps until potential field optimization.

Expectations:
* the image is loaded as a layer named “Image”,
* the “Image” layer is moved to the bottom the layer stack,
* the Image layers that represents potential fields are not moved to the bottom,
* image cropping is triggered specifically in scenario (2),
* not any layer of type other than Image is affected by the changes.

# Limitations

I haven't found a way to enforce use of the `napari-itk-io` file reading plugin for the native file loading mechanims.