### PR TITLE
fix(Open Sample): File > Open Sample > Differentiable Potential Field…

### DIFF
--- a/src/napari_potential_field_navigation/_use_case.py
+++ b/src/napari_potential_field_navigation/_use_case.py
@@ -167,20 +167,23 @@ class UseCase:
                 self.disable(step)
 
 
-def use_case_check_point(f_or_layer):
+def use_case_check_point(f_or_layers):
     """
     Decorator for methods that may fulfill use case requirements.
     """
 
-    if isinstance(f_or_layer, str):
-        layer = f_or_layer
+    if isinstance(f_or_layers, (str, list, tuple)):
+        layers = f_or_layers
+        if isinstance(layers, str):
+            layers = [layers]
 
         def decorator(f):
 
             @wraps(f)
             def method_with_check_point(self, *args, **kwargs):
                 ret = f(self, *args, **kwargs)
-                self._use_case.notify_layer_update(self, layer, ret)
+                for layer in layers:
+                    self._use_case.notify_layer_update(self, layer, ret)
                 return ret
 
             return method_with_check_point
@@ -188,7 +191,7 @@ def use_case_check_point(f_or_layer):
         return decorator
 
     else:
-        f = f_or_layer
+        f = f_or_layers
 
         @wraps(f)
         def method_with_check_point(self, *args, **kwargs):

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -160,7 +160,7 @@ class IoContainer(widgets.Container):
             ## TODO : uncomment to get the image at the right resolution
             self._viewer.layers["Image"].translate = new_origin
 
-    @use_case_check_point("Image")
+    @use_case_check_point(["Image", "Label"])
     def _handle_layers_from_other_readers(self, event):
         # the newly inserted layer is the last one in the layer list
         layer = event.source[-1]


### PR DESCRIPTION
This restores a specific file loading use case:

“File” > “Open Sample” > “Differentiable Potential Field Navigation” > “Image / Label Samples”

The explicit use case specification introduced by PR [!5](https://github.com/rcremese/napari-potential-field-navigation/pull/5) did not account for this specific case.

# Changes

The `@use_case_check_point` decorator now also admits a list of layers.

On completion, the `_handle_layers_from_other_readers` method is followed by a check on both the “Image” layer and the “Label” layer, because this method is called every time an image or label file is loaded (every time a layer is added).