### PR TITLE
feat: FocusedWalkers simulation, spatial average trajectory

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     numpy
     magicgui
     qtpy
+    scikit-learn
     scikit-image
     napari-itk-io
     taichi

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -1420,8 +1420,7 @@ class SimulationContainer(widgets.Container):
                 self.simulation.run()
                 if goal_weight > 0.0:
                     self.simulation.compute_distance_loss(
-                        # self.simulation.nb_steps - 1
-                        i / max_iter
+                        self.simulation.nb_steps - 1
                     )
                 if bend_weight > 0.0:
                     self.simulation.compute_bend_loss(min_diff=1e-6)

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -33,8 +33,12 @@ from napari_potential_field_navigation._finite_difference import (
 
 from napari_potential_field_navigation.geometries import Box3D
 from napari_potential_field_navigation.simulations import (
-    FreeNavigationSimulation,
     DomainNavigationSimulation,
+)
+from napari_potential_field_navigation.focused_walkers import (
+    FocusedWalkers,
+    set_simulation_default_values_for_lung,
+    reset_simulation_default_values,
 )
 import csv
 
@@ -165,15 +169,18 @@ class IoContainer(widgets.Container):
             ## TODO : uncomment to get the image at the right resolution
             self._viewer.layers["Image"].translate = new_origin
 
+    @classmethod
+    def _is_misnamed_image_layer(cls, layer):
+        return (isinstance(layer, napari.layers.image.image.Image)
+            and layer.name not in ("Image", "Label_temp", "Density")
+            and not layer.name.endswith(" field")
+        )
+
     @use_case_check_point(["Image", "Label"])
     def _handle_layers_from_other_readers(self, event):
         # the newly inserted layer is the last one in the layer list
         layer = event.source[-1]
-        if (
-            isinstance(layer, napari.layers.image.image.Image)
-            and layer.name not in ("Image", "Label_temp", "Density")
-            and not layer.name.endswith(" field")
-        ):
+        if self._is_misnamed_image_layer(layer):
             # the layer has been added using the viewer or File menu, i.e.
             # by copy-paste, drag-n-drop, Ctrl+O or File > Open File(s)...
             if "Image" in self._viewer.layers:
@@ -246,7 +253,11 @@ class PointContainer(widgets.Container):
 
     def _on_add_point(self, layer, event):
         if layer.mode == "add" and layer.editable:
-            layer.add(event.position)
+            pos = event.position
+            if len(pos) == 4:
+                # time has been appended as first coordinate; remove it
+                pos = pos[1:]
+            layer.add(pos)
             layer.editable = False
             self._source_selection.text = "Edit goal"
 
@@ -966,7 +977,7 @@ class SimulationContainer(widgets.Container):
         self._field_container = field_container
         self._time_slider = widgets.FloatSpinBox(
             min=1,
-            max=10_000,
+            max=1_000_000_000,
             value=100,
             step=1,
             label="Simulation final time (s)",
@@ -980,28 +991,31 @@ class SimulationContainer(widgets.Container):
         )
         self._speed_slider = widgets.FloatSpinBox(
             min=0,
-            max=10,
+            max=1_000,
             value=0,
             step=0.1,
             label="Maximal speed (cm/s)",
         )
         self._diffusivity_slider = widgets.FloatSpinBox(
             min=0,
-            max=10,
+            max=1_000,
             value=0,
             step=1e-3,
             label="Agent diffusivity (cm^2/s)",
         )
         ## Button to start the simulation
         self._agent_count = widgets.SpinBox(
-            label="Number of agents", min=1, max=100, value=1
+            label="Number of agents", min=1, max=1_000_000, value=1
         )
         self._reset_button = widgets.ComboBox(
             label="Vector field init",
-            value="Reset",
-            choices=["Reset", "Keep best", "Keep lastest"],
+            value="None",
+            choices=["None", "Reset", "Keep best", "Keep lastest"],
         )
         self._reset_button.enabled = False
+        self._viewer.layers.events.inserted.connect(
+            self._update_reset_button_on_field_init
+        )
         ## Widget container
         simu_param_container = widgets.Container(
             widgets=[
@@ -1034,7 +1048,7 @@ class SimulationContainer(widgets.Container):
         ## Optimization widgets
         ## Classical optimization parameters
         self._nb_epochs_box = widgets.SpinBox(
-            label="Epochs", min=1, max=1000, step=10, value=10
+            label="Epochs", min=1, max=1_000_000, step=10, value=10
         )
         self._lr_slider = widgets.FloatSpinBox(
             min=1e-4, max=10, value=0.1, step=1e-4, label="Learning rate"
@@ -1184,6 +1198,9 @@ class SimulationContainer(widgets.Container):
         self.losses = None
         self._optimized_vector_field = None
 
+        if self._reset_button.value == "None":
+            set_simulation_default_values_for_lung(self)
+
     def _run_simulation(self) -> bool:
         # self._start_button.text = "Running simulation..."
         # self._start_button.enabled = False
@@ -1216,8 +1233,9 @@ class SimulationContainer(widgets.Container):
         if self.nb_agents == 1:
             return True
         ## Plot the mean trajectory
-        if f"Mean {name.lower()}" in self._viewer.layers:
-            self._viewer.layers.remove(f"Mean {name.lower()}")
+        layer_name = f"Mean {name.lower()}"
+        if layer_name in self._viewer.layers:
+            self._viewer.layers.remove(layer_name)
         self._viewer.add_tracks(
             self.mean_trajectories[
                 ["trajectory id", "frame index", "x", "y", "z"]
@@ -1225,7 +1243,9 @@ class SimulationContainer(widgets.Container):
             color_by="track_id",
             colormap="hsv",
             blending="translucent",
-            name=f"Mean {name.lower()}",
+            name=layer_name,
+            tail_width=20,
+            tail_length=self.simulation._nb_steps,
         )
         return True
 
@@ -1284,7 +1304,9 @@ class SimulationContainer(widgets.Container):
         return True
 
     def _initialize_simulation(self) -> bool:
-        if self._reset_button.value == "Reset":
+        if self._reset_button.value == "None":
+            vector_field = self.empty_vector_field()
+        elif self._reset_button.value == "Reset":
             vector_field = self._field_container.vector_field
             ## Normalize the vector field (because it's too slow otherwise)
             vector_field.normalize()
@@ -1341,11 +1363,12 @@ class SimulationContainer(widgets.Container):
         goal = self._viewer.layers["Goal"].data[0]
         assert goal.shape == (3,), "Goal position must be a 3D vector"
 
-        self.simulation = DomainNavigationSimulation(
+        self.simulation = FocusedWalkers(
             initial_positions,
             goal,
             vector_field,
             distance_field=distance_field,
+            domain=label_layer.data,
             t_max=self.tmax,
             dt=self.dt,
             diffusivity=self.diffusivity,
@@ -1397,7 +1420,8 @@ class SimulationContainer(widgets.Container):
                 self.simulation.run()
                 if goal_weight > 0.0:
                     self.simulation.compute_distance_loss(
-                        self.simulation.nb_steps - 1
+                        # self.simulation.nb_steps - 1
+                        i / max_iter
                     )
                 if bend_weight > 0.0:
                     self.simulation.compute_bend_loss(min_diff=1e-6)
@@ -1624,18 +1648,49 @@ class SimulationContainer(widgets.Container):
         if self.simulation is None:
             notifications.show_error("No simulation found.")
             return None
-        if self.nb_agents == 1:
-            return self.trajectories
-
-        mean_traj = self.trajectories.groupby(["source", "frame index"]).mean()
-        mean_traj["trajectory id"] = np.repeat(
-            range(self.nb_sources), self.simulation.nb_steps
-        ).astype(int)
-        mean_traj["frame index"] = np.tile(
-            range(self.simulation.nb_steps), self.nb_sources
+        sim_trajectories = self.simulation.mean_trajectory
+        trajectories = pd.DataFrame(
+            sim_trajectories,
+            columns=["trajectory id", "frame index", "x", "y", "z"],
         )
-        return mean_traj
+        return trajectories
 
+    def empty_vector_field(self) -> VectorField3D:
+        if "Label" not in self._viewer.layers:
+            notifications.show_error(
+                "No labels found. Please select a label file before running the optimization."
+            )
+            return None
+        label_layer = self._viewer.layers["Label"]
+        starting = np.array(label_layer.translate)
+        spacing = np.array(label_layer.scale)
+        ending = starting + spacing * label_layer.data.shape
+        bounds = Box3D(starting, ending)
+
+        data = np.zeros((*label_layer.data.shape, 3), dtype=np.float32)
+        x, y, z = np.nonzero(label_layer.data)
+        for w in range(3):
+            data[x, y, z, w] = 1e-8 * np.random.randn(len(x))
+
+        return SimpleVectorField3D(data, bounds)
+
+    def _field_init_event(self, event):
+        layer = event.source[-1]
+        return (layer.name.endswith(" field")
+            and layer.name != "Optimized vector field"
+            and self._reset_button.value == "None"
+        )
+
+    def _update_reset_button_on_field_init(self, event):
+        # if _reset_button is "None" and initialization has just completed,
+        # change _reset_button's value to previous default "Reset", and thus
+        # preserve the original behavior.
+        if self._field_init_event(event):
+            self._reset_button.value = "Reset"
+            logging.info(
+                "Resetting simulation and optimization parameters to original defaults."
+            )
+            reset_simulation_default_values(self)
 
 class DiffApfWidget(widgets.Container):
     def __init__(self, viewer: "napari.viewer.Viewer"):
@@ -1695,7 +1750,7 @@ class DefaultUseCase(UseCase):
         ]
         self._requirements[SimulationContainer] = [
             "Initial positions",
-            InitFieldContainer.compute,
+            #InitFieldContainer.compute,
         ]
         if InitFieldContainer is AStarContainer:
             self._requirements[InitFieldContainer].append(

--- a/src/napari_potential_field_navigation/_widget.py
+++ b/src/napari_potential_field_navigation/_widget.py
@@ -1647,12 +1647,12 @@ class SimulationContainer(widgets.Container):
         if self.simulation is None:
             notifications.show_error("No simulation found.")
             return None
-        sim_trajectories = self.simulation.mean_trajectory
-        trajectories = pd.DataFrame(
-            sim_trajectories,
+        mean_traj = self.simulation.mean_trajectory
+        mean_traj = pd.DataFrame(
+            mean_traj,
             columns=["trajectory id", "frame index", "x", "y", "z"],
         )
-        return trajectories
+        return mean_traj
 
     def empty_vector_field(self) -> VectorField3D:
         if "Label" not in self._viewer.layers:

--- a/src/napari_potential_field_navigation/fields.py
+++ b/src/napari_potential_field_navigation/fields.py
@@ -217,7 +217,7 @@ class VectorField2D(SampledField2D):
         ## Dimension and values
         if values.ndim != 3 or values.shape[2] != 2:
             raise ValueError(
-                f"Expected sampled field to be 3D-array with first dimension of size 2. Get {values.ndim} dimensions and first dimension of size {values.shape[0]}"
+                f"Expected sampled field to be 3D-array with last dimension of size 2. Get {values.ndim} dimensions and last dimension of size {values.shape[2]}"
             )
         self._values = ti.Vector.field(
             n=self.ndim,
@@ -371,7 +371,7 @@ class VectorField3D(SampledField3D):
         ## Dimension and values
         if values.ndim != 4 or values.shape[3] != 3:
             raise ValueError(
-                f"Expected sampled field to be 4D-array with first dimension of size 3. Get {values.ndim} dimensions and first dimension of size {values.shape[3]}"
+                f"Expected sampled field to be 4D-array with last dimension of size 3. Get {values.ndim} dimensions and last dimension of size {values.shape[3]}"
             )
         self._values = ti.Vector.field(
             n=self.ndim,
@@ -419,13 +419,13 @@ class SampledFieldFactory:
         if isinstance(bounds, Box2D):
             if values.ndim != 3 or values.shape[2] != 2:
                 raise ValueError(
-                    f"Expected values to be 3D-array with first dimension of size 2. Get {values.ndim} dimensions and first dimension of size {values.shape[0]}"
+                    f"Expected values to be 3D-array with last dimension of size 2. Get {values.ndim} dimensions and last dimension of size {values.shape[2]}"
                 )
             return VectorField2D(values, bounds)
         elif isinstance(bounds, Box3D):
             if values.ndim != 4 or values.shape[3] != 3:
                 raise ValueError(
-                    f"Expected values to be 4D-array with first dimension of size 3. Get {values.ndim} dimensions and first dimension of size {values.shape[0]}"
+                    f"Expected values to be 4D-array with last dimension of size 3. Get {values.ndim} dimensions and last dimension of size {values.shape[3]}"
                 )
             return VectorField3D(values, bounds)
         else:

--- a/src/napari_potential_field_navigation/focused_walkers.py
+++ b/src/napari_potential_field_navigation/focused_walkers.py
@@ -24,7 +24,7 @@ class FocusedWalkers(DomainNavigationSimulation):
         )
 
     @ti.kernel
-    def compute_distance_loss(self, maturity: float):
+    def compute_distance_loss(self, t_max: int):
         for n in range(self._nb_walkers):
             self.distance_loss[None] += (
                 self._min_normalized_squared_distance_to_target[n]
@@ -170,7 +170,7 @@ def local_scale_transform(volume):
     direction as well. It takes the distance between the first background
     elements in both directions as a measurement of the local available “room”.
 
-    This is used to automatically adjust the local diffusivity.
+    This is used to threshold the norm of the random displacements.
     """
     nearest = distance_transform_edt(
         volume,

--- a/src/napari_potential_field_navigation/focused_walkers.py
+++ b/src/napari_potential_field_navigation/focused_walkers.py
@@ -1,0 +1,380 @@
+import taichi as ti
+import taichi.math as tm
+import numpy as np
+from scipy.ndimage import distance_transform_edt
+from napari_potential_field_navigation.fields import DistanceField
+
+from napari_potential_field_navigation.simulations import (
+    DomainNavigationSimulation,
+)
+
+class FocusedWalkers(DomainNavigationSimulation):
+    """
+    FocusedWalkers feature decreasing diffusion as they get closer to the
+    target. This strategy makes it possible to start with high noise level
+    while still targeting locations in tight volumes. In addition, a walker
+    will stay around the target once reached.
+    """
+    def __init__(self, *args, **kwargs):
+        domain = kwargs.pop("domain")
+        super().__init__(*args, **kwargs)
+        self._local_diameter: DistanceField = DistanceField(
+            local_scale_transform(domain),
+            self.vector_field._bounds,
+        )
+
+    @ti.kernel
+    def compute_distance_loss(self, maturity: float):
+        for n in range(self._nb_walkers):
+            self.distance_loss[None] += (
+                self._min_normalized_squared_distance_to_target[n]
+            )
+
+    def update_time(self, t_max: float, dt: float):
+        super().update_time(t_max, dt)
+        self._normalized_squared_distance_to_target: ti.Field = ti.field(
+            dtype=ti.f32,
+            shape=(self._nb_walkers, self._nb_steps),
+            needs_grad=True,
+        )
+        self._min_normalized_squared_distance_to_target: ti.Field = ti.field(
+            dtype=ti.f32,
+            shape=(self._nb_walkers, ),
+            needs_grad=True,
+        )
+        self._initial_squared_distance_to_target: ti.Field = ti.field(
+            dtype=ti.f32,
+            shape=(self._nb_walkers, ),
+            needs_grad=False,
+        )
+
+    # augmented copies of DomainNavigationSimulation implementations
+    @ti.kernel
+    def _reset_2d(self):
+        for n in ti.ndrange(self._nb_walkers):
+            self._positions[n, 0] = self._init_pos[n]
+            for t in ti.ndrange(self._nb_steps):
+                self._noise[n, t] = tm.vec2(ti.randn(), ti.randn())
+            # addition
+            dr = self._init_pos[n] - self.target
+            self._initial_squared_distance_to_target[n] = tm.dot(dr, dr)
+            self._normalized_squared_distance_to_target[n, 0] = 1.
+            self._min_normalized_squared_distance_to_target[n] = 1.
+            #
+        for i, j in self.vector_field._values:
+            self.vector_field._values.grad[i, j] = tm.vec2(0.0, 0.0)
+
+    @ti.kernel
+    def _reset_3d(self):
+        for n in ti.ndrange(self._nb_walkers):
+            self._positions[n, 0] = self._init_pos[n]
+            for t in ti.ndrange(self._nb_steps):
+                self._noise[n, t] = tm.vec3(ti.randn(), ti.randn(), ti.randn())
+            # addition
+            dr = self._init_pos[n] - self.target
+            self._initial_squared_distance_to_target[n] = tm.dot(dr, dr)
+            self._normalized_squared_distance_to_target[n, 0] = 1.
+            self._min_normalized_squared_distance_to_target[n] = 1.
+            #
+        for i, j, k in self.vector_field._values:
+            self.vector_field._values.grad[i, j, k] = tm.vec3(0.0, 0.0, 0.0)
+
+    @ti.func
+    def scale_diffusivity( self, diffusivity: ti.f32, distance: ti.f32):
+        return diffusivity * distance
+
+    @ti.kernel
+    def step(self, t: int, diffusivity: ti.f32):
+        for n in ti.ndrange(self._nb_walkers):
+            p = self._positions[n, t - 1]
+
+            diffusivity_n = self.scale_diffusivity(
+                diffusivity,
+                tm.sqrt(self._normalized_squared_distance_to_target[n, t - 1]),
+            )
+
+            random_displacement = (
+                tm.sqrt(2 * self._dim * self._dt * diffusivity_n)
+                * self._noise[n, t]
+            )
+
+            # adjusting the diffusion helps, especially with making the walkers
+            # stop by the target, but thresholding the norm of the actual
+            # random displacement is necessary to reduce the rate of
+            # cross-boundary jumps
+            rd_norm = tm.length(random_displacement)
+            rd_norm_max = self._local_diameter.at(p) / 2
+            if rd_norm_max < rd_norm:
+                random_displacement *= rd_norm_max / rd_norm
+
+            self._positions[n, t] = (
+                p + self._dt * self.vector_field.at(p) + random_displacement
+            )
+            self.collision_handling(n, t)
+
+            dr = self._positions[n, t] - self.target
+            d2 = self._normalized_squared_distance_to_target[n, t] = (
+                tm.dot(dr, dr) / self._initial_squared_distance_to_target[n]
+            )
+            ti.atomic_min(
+                self._min_normalized_squared_distance_to_target[n], d2
+            )
+
+    @property
+    def mean_trajectory(self) -> np.ndarray:
+        mean_positions = mean_trajectory(
+            self.positions,
+            self._init_pos.to_numpy()[0,:],
+            self.target.to_numpy(),
+            self._min_normalized_squared_distance_to_target.to_numpy(),
+        )
+        ids = np.zeros(self.nb_steps, dtype=int)
+        times = np.arange(self.nb_steps, dtype=int)
+        return np.column_stack((ids, times, mean_positions))
+
+
+def set_simulation_default_values_for_lung(container):
+    container._time_slider.value = 2_000
+    container._speed_slider.value = 1.
+    container._diffusivity_slider.value = 5.
+    container._agent_count.value = 2_000
+    container._lr_slider.value = .5
+    container._nb_epochs_box.value = 200 # without diffusion scaling
+    # empirical rule: add 100 epochs for each unit of diffusion difference
+    # between min and max
+    container._nb_epochs_box.value = 500
+    container._diffusion_decrease.value = "Linear"
+    container._diffusion_max.value = 5.
+    container._diffusion_min.value = 2.
+    container._goal_distance.value = 1.
+    container._bending_constraint.value = 0.
+    container._obstacle_distance.value = 0.
+
+def reset_simulation_default_values(container):
+    container._time_slider.value = 100
+    container._speed_slider.value = 0
+    container._diffusivity_slider.value = 0
+    container._agent_count.value = 1
+    container._nb_epochs_box.value = 10
+    container._lr_slider.value = 0.1
+    container._diffusion_decrease.value = "None"
+    container._diffusion_max.value = 0
+    container._diffusion_min.value = 0
+    container._goal_distance.value = 1.0
+    container._bending_constraint.value = 1.0
+    container._obstacle_distance.value = 1.0
+
+def local_scale_transform(volume):
+    """
+    Similar to scipy.ndimage.distrance_transform_edt, but looks at the opposite
+    direction as well. It takes the distance between the first background
+    elements in both directions as a measurement of the local available “room”.
+
+    This is used to automatically adjust the local diffusivity.
+    """
+    nearest = distance_transform_edt(
+        volume,
+        return_distances=False,
+        return_indices=True,
+    )
+    local = np.stack(
+        np.meshgrid(
+            *[np.arange(d) for d in volume.shape],
+            indexing='ij',
+        ),
+        axis=0,
+    )
+    opposite = 2 * local - nearest
+    step = (local - nearest).astype(float)
+    norm = np.sqrt((step * step).sum(axis=0))
+    norm[norm <= 0] = 1
+    step /= norm
+    #
+    active = volume == 1
+    ndim = opposite.shape[0]
+    n = active.sum()
+    while  0 < n:
+        outofbounds = np.zeros(n, dtype=bool)
+        update = []
+        for i in range(ndim):
+            r = opposite[i, ...][active].astype(float)
+            dr = step[i, ...][active]
+            # step
+            search_head = np.round(r + dr).astype(int)
+            update.append(search_head)
+            outofbounds |= search_head < 0
+            outofbounds |= volume.shape[i] <= search_head
+        # discard out-of-bounds heads
+        active[active] = ~outofbounds
+        update = [head[~outofbounds] for head in update]
+        # discard heads in the background
+        foreground = volume[tuple(update)] == 1
+        active[active] = foreground
+        update = np.stack([head[foreground] for head in update], axis=0)
+        # update opposite positions
+        for i in range(ndim):
+            broadcast_active = np.zeros(opposite.shape, dtype=active.dtype)
+            broadcast_active[i] = active
+            opposite[broadcast_active] = update[i]
+        n = active.sum()
+    # return Euclidean distance between nearest and opposite positions
+    diameter = opposite - nearest
+    diameter = np.sqrt((diameter * diameter).sum(axis=0))
+    return diameter
+
+def mean_trajectory(
+    positions,
+    origin,
+    destination,
+    squared_distance=None,
+    squared_radius=None,
+    chunk_size=100,
+    downsampling_step=10,
+):
+    time_average = np.mean(positions, axis=0) # for later usage
+    ### 1. compute a path using a moving space window
+    ## format the input arrays
+    origin = origin.flatten()
+    destination = destination.flatten()
+    ## select the 10% best trajectories and make precalculations for L2
+    # distances with the following standard vectorized formula:
+    # ||x-y||^2 = -2 * <x,y> + ||x||^2 + transpose(||y||^2)
+    q2 = (destination * destination).sum(axis=-1)
+    if squared_distance is None:
+        terminals = positions[:, -1, :]
+        p2 = (terminals * terminals).sum(axis=-1)
+        d2 = -2 * np.inner(terminals, destination) + p2 + q2
+    else:
+        d2 = squared_distance
+    # positions' shape is (nb_walkers, nb_steps, space_dims)
+    n, t, d = positions.shape
+    n_ = n // 10
+    best_trajectories = np.argsort(d2)[:n_]
+    positions_ = positions[best_trajectories, 1:, :]
+    t_ = t - 1
+    assert positions_.shape == (n_, t_, d)
+    positions_ = positions_.reshape((n_ * t_, -1))
+    p2 = (positions_ * positions_).sum(axis=-1)
+    ## initialize
+    moving_average = origin
+    r2 = np.dot(moving_average, moving_average)
+    d2_t = d2_t0 = np.inf # will be the distance to the target
+    radius2_scale = 1.
+    not_visited = np.ones(p2.shape, dtype=bool) # greedy-search indicator
+    path = []
+    ## determine the search radius
+    if squared_radius is None:
+        max_jump = destination - origin
+        max_radius2 = np.dot(max_jump, max_jump)
+        radius2 = max_radius2 / (10 * 10)
+        # # search for nearest neighbors of the origin point among the first
+        # # time steps
+        # m = 10 * n_
+        # d2 = -2 * np.inner(positions_[:m], moving_average) + p2[:m] + r2
+        # i = np.argsort(d2)
+        # m_ = max(10, n_ // 4) # another arbitrary threshold that implicitly
+        # # determines the search radius (squared).
+        # # discard points that did not move from (or came back to) the origin
+        # if d2[i[0]] == 0:
+        #     m_ += (d2 == 0).sum()
+        #     m_ = min(m_, m)
+        # i = i[:m_]
+        # radius2 = d2[i[-1]]
+        # print(f'mean_trajectory: search radius = {np.sqrt(radius2)}')
+        # moving_average = np.mean(positions_[i, :], axis=0) # first point
+        # not_visited[i] = False
+        # # squared distance to target
+        # r2 = (moving_average * moving_average).sum(axis=-1)
+        # d2_t = -2 * np.dot(destination, moving_average) + q2 + r2
+        # # initialize
+        # path = [moving_average]
+    else:
+        radius2 = squared_radius
+    ## build up the path
+    while np.any(not_visited) and radius2 < d2_t:
+        d2 = (
+            -2 * np.inner(positions_[not_visited, :], moving_average)
+            + p2[not_visited] + r2
+        )
+        # # scale the radius wrt the distance to the target
+        # if not np.isinf(d2_t):
+        #     radius2_scale = 1.
+        #     radius2_scale = d2_t / d2_t0
+        # 3 times the (scaled) radius; this again is arbitrary
+        I = d2 <= 9 * radius2_scale * radius2
+        if not np.any(I): break
+        i = not_visited.nonzero()[0][I]
+        moving_average = np.mean(positions_[i, :], axis=0)
+        not_visited[i] = False
+        path.append(moving_average)
+        # squared distance to target
+        r2 = (moving_average * moving_average).sum(axis=-1)
+        d2_t = -2 * np.dot(destination, moving_average) + q2 + r2
+        if np.isinf(d2_t0):
+            d2_t0 = d2_t # distance to target of the first path point
+    ## add a last path point near the target, without the greedy indicator
+    if radius2 < d2_t:
+        d2 = -2 * np.inner(positions_, destination) + p2 + q2
+        I = d2 <= radius2
+        moving_average = np.mean(positions_[I, :], axis=0)
+        path.append(moving_average)
+    else:
+        print('mean_trajectory: target not reached')
+    ### 2. resample the path over time ]0,t];
+    # note we exclude 0 for a practical concern and
+    time_progress = np.arange(0, t + 1, downsampling_step)[1:] / t
+    space_progress = np.diff(np.stack(path, axis=0), axis=0)
+    space_progress = (space_progress * space_progress).sum(axis=-1)
+    space_progress = np.r_[0., np.cumsum(space_progress)]
+    space_progress /= space_progress[-1]
+    # deal with numerical precision errors
+    space_progress[0] = 0.
+    space_progress[-1] = 1.
+    assert time_progress[-1] <= space_progress[-1]
+    new_path = [path[0]] # because we excluded 0 from time_progress
+    for p in time_progress:
+        k = (p <= space_progress).nonzero()[0][0]
+        assert 0 < k # because we excluded 0 from time_progress
+        # interpolate within segment [k-1,k]
+        p0, p1 = space_progress[k - 1] , space_progress[k]
+        point = (
+            (p1 - p) / (p1 - p0) * path[k - 1]
+            + (p - p0) / (p1 - p0) * path[k]
+        )
+        new_path.append(point)
+    path = np.stack(new_path, axis=0)
+    ### 3. adjust the mean positions to the actual positions on a
+    # nearest-neighbor basis; here we could use all the trajectories but in
+    # practice this might take too much resources (memory or compute time)
+    q2 = (path * path).sum(axis=-1)
+    t__ = path.shape[0]
+    p2 = np.atleast_2d(p2).T # column vector
+    m = n // 2 # another arbitrary threshold on the number of points
+    new_path = []
+    for k in range(t__ // chunk_size + 1):
+        k *= chunk_size
+        if k == t__: break
+        l = min(k + chunk_size, t__)
+        chunk = path[k:l, :]
+        q2k = np.atleast_2d(q2[k:l]) # row vector
+        d2 = -2 * np.inner(positions_, chunk) + p2 + q2k
+        i = np.argsort(d2, axis=0)[0:m, :]
+        for j in range(i.shape[1]):
+            new_mean = np.mean(positions_[i[:, j], :], axis=0)
+            new_path.append(new_mean)
+    path = np.stack(new_path, axis=0)
+    ### 4. upsample to compensate for the previous downsampling
+    if 1 < downsampling_step:
+        new_path = []
+        grid = np.linspace(0., 1., downsampling_step + 1)
+        for k in range(1, path.shape[0]):
+            p0, p1 = path[k - 1, :], path[k, :]
+            segment = np.outer(grid[::-1], p0) + np.outer(grid, p1)
+            # we could avoid dropping the last point of the last segment,
+            # however, as path points are interval bounds, we have to drop 1
+            # point anyway
+            segment = segment[:-1, :]
+            new_path.append(segment)
+        path = np.concatenate(new_path, axis=0)
+    return path
+

--- a/src/napari_potential_field_navigation/simulations.py
+++ b/src/napari_potential_field_navigation/simulations.py
@@ -36,7 +36,7 @@ class NavigationSimulation(ABC):
         super().__init__()
         self._init_pos: ti.Field = None
         self._positions: ti.Field = None
-        self._target: ti.Vector = None
+        self.target: ti.Vector = None
         self._noise: ti.Field = None
         self._nb_steps: int = None
         self._nb_walkers: int = None
@@ -97,7 +97,7 @@ class FreeNavigationSimulation(NavigationSimulation):
         ## Initialisation of the walkers positions
         self.update_positions(positions)
 
-        ## Initiailisation of the taget point
+        ## Initialisation of the target point
         if target.shape != (self._dim,):
             raise ValueError(
                 f"Expected target to be a {self._dim}D-array. Get {target.shape} array"


### PR DESCRIPTION
This giant PR (sorry) aims to implement an alternative simulation algorithm and hyperparameter preset that work on the lung data example and, most notably, **without initialization** (no APF, just a null initial vector field).

The general principle of this new approach consists in setting the diffusion to extremely high levels (most initial jumps bump into the walls) so that walkers get a chance to approach the target point, and decreasing the diffusivity as a walker approaches the target point, so that such a walker sticks around that point. This strategy is expected to work in closed/confined environments only.

To handle the undesirable jumps through the walls that result from such high diffusions, the norm of the generated random displacements are thresholded using a diameter estimate of the local available space. This estimate is produced by a custom alternative implementation of the Euclidean transform.

Last but not least, the temporal mean trajectories are replaced by spatial mean trajectories. This change is important here, as the highly noisy individual trajectories are clearly not good candidate paths. The resulting vector field is neither good-enough to draw a noise-free path. The only viable approach to drawing a reasonable path consists in averaging the individual trajectories in space. This is implemented with a greedy approach that admits several parameters whose default values work okay on the lung data example, but may exhibit weird behaviors on other data examples.

As a general observation, the noisy approach makes the optimized vector field exhibit an attraction bassin around the target that may not include the origin point, because the diffusion and the number of points per trajectory are sufficient for most trajectories to reach the attraction bassin. This is why the optimized vector field cannot be used to draw a resulting path.

The hyperparameter preset (this PR brings in) uses the pre-existing diffusion decreasing mechanism over the optimization process. However, this decrease has to be slow, and results in a large (and poorly calibrated) increase in the number of optimization steps.

The obstacle loss and the bending loss are excluded for now. In particular, removing the obstacle loss made the simulations a lot more robust in reaching the target point; otherwise the trajectories could occasionnaly go into the opposite direction (all of them) and cluster in a distant corner. As another general observation, the tweaking process of the simulation/optimization procedure is very sensitive to most changes in hyperparameters. To deal with a new data example, it is advisable to begin with the distance loss only and no diffusion decrease over the optimization process. Once the simulation and optimization seem to work together, one may activate more options (*e.g.* a diffusion decrease) and losses to improve the resulting vector field and mean trajectory. As a consequence, this PR does not even consider the other losses.

Most changes are contained in an additional *focused_walkers.py* module.

This PR also modifies the *_widget.py* module to increase the upper bound on a few hyperparameters, fix a bug with target point selection after the time dimension has been added, add "None" as an option in the initialization panel, generate a null vector field, disable the requirement of an initial field layer to unlock the simulation and optimization panels, and accommodate the new simulator and the spatial mean trajectory calculation.

The new simulation class and spatial mean trajectory should be easy enough to disable to make the program works as without this PR.

Finally, the PR adds a missing Python dependency.